### PR TITLE
docs: beacon → neo (@mdxui/beacon deprecated per SG-7)

### DIFF
--- a/ABSTRACTION.md
+++ b/ABSTRACTION.md
@@ -25,7 +25,7 @@ SaaSkit derives multiple artifacts from a single noun/verb schema:
 |--------|-------------|----------------|
 | **App** | React admin dashboard | Uses `@mdxui/admin` components |
 | **API** | REST + GraphQL + WebSocket | Pure TypeScript (no UI deps) |
-| **Site** | Landing page | Uses `@mdxui/beacon` |
+| **Site** | Landing page | Uses `@mdxui/neo` (sections) + `@mdxui/blocks` (block data) |
 | **Docs** | API reference | Uses Fumadocs |
 | **CLI** | Command-line interface | Pure TypeScript |
 | **MCP** | Model Context Protocol server | Pure TypeScript |
@@ -215,7 +215,7 @@ interface UseResourceResult<T> {
 | Admin UI components | `@mdxui/admin` |
 | App shell/layout | `@mdxui/app` |
 | Base primitives | `@mdxui/primitives` |
-| Landing pages | `@mdxui/beacon` |
+| Landing pages | `@mdxui/neo` + `@mdxui/blocks` |
 | Backend integration | `@dotdo/react` |
 | Data fetching patterns | `@mdxui/app/hooks` |
 

--- a/ABSTRACTION.md
+++ b/ABSTRACTION.md
@@ -25,7 +25,7 @@ SaaSkit derives multiple artifacts from a single noun/verb schema:
 |--------|-------------|----------------|
 | **App** | React admin dashboard | Uses `@mdxui/admin` components |
 | **API** | REST + GraphQL + WebSocket | Pure TypeScript (no UI deps) |
-| **Site** | Landing page | Uses `@mdxui/neo` (sections) + `@mdxui/blocks` (block data) |
+| **Site** | Landing page | Targets `@mdxui/neo` (sections) + `@mdxui/blocks` (block data); generator still emits `'@mdxui/beacon'` strings (migration queued) |
 | **Docs** | API reference | Uses Fumadocs |
 | **CLI** | Command-line interface | Pure TypeScript |
 | **MCP** | Model Context Protocol server | Pure TypeScript |
@@ -215,7 +215,7 @@ interface UseResourceResult<T> {
 | Admin UI components | `@mdxui/admin` |
 | App shell/layout | `@mdxui/app` |
 | Base primitives | `@mdxui/primitives` |
-| Landing pages | `@mdxui/neo` + `@mdxui/blocks` |
+| Landing pages | `@mdxui/neo` + `@mdxui/blocks` (successor to deprecated `@mdxui/beacon`) |
 | Backend integration | `@dotdo/react` |
 | Data fetching patterns | `@mdxui/app/hooks` |
 

--- a/README.md
+++ b/README.md
@@ -988,7 +988,7 @@ SaaSkit sits at the **generation layer** - it takes DSL definitions (Nouns + Ver
 | Output | Using |
 |--------|-------|
 | **App** | React components (raw + @mdxui/cockpit) |
-| **Site** | @mdxui/neo section components |
+| **Site** | @mdxui/neo section components (target; @mdxui/beacon literals pending migration) |
 | **API** | Self-contained REST/GraphQL/WebSocket |
 | **Docs** | MDX documentation |
 | **CLI** | Command-line interface |

--- a/README.md
+++ b/README.md
@@ -967,7 +967,7 @@ SaaSkit sits at the **generation layer** - it takes DSL definitions (Nouns + Ver
 └─────────────────────────────────────────────────────────────────┘
                               ↓ implements
 ┌─────────────────────────────────────────────────────────────────┐
-│              @mdxui/beacon + @mdxui/cockpit (templates)          │
+│             @mdxui/neo + @mdxui/cockpit (templates)              │
 │   Site sections, App dashboards, Auth flows                      │
 └─────────────────────────────────────────────────────────────────┘
                               ↓ generates to
@@ -988,7 +988,7 @@ SaaSkit sits at the **generation layer** - it takes DSL definitions (Nouns + Ver
 | Output | Using |
 |--------|-------|
 | **App** | React components (raw + @mdxui/cockpit) |
-| **Site** | @mdxui/beacon components |
+| **Site** | @mdxui/neo section components |
 | **API** | Self-contained REST/GraphQL/WebSocket |
 | **Docs** | MDX documentation |
 | **CLI** | Command-line interface |

--- a/src/generators/site.ts
+++ b/src/generators/site.ts
@@ -2,7 +2,7 @@
  * Site Generator - Marketing Landing Page Generation
  *
  * Generates a marketing landing page from the app definition.
- * Uses @mdxui/neo section components for the UI.
+ * Targets @mdxui/neo section components for the UI.
  * (@mdxui/beacon is deprecated — superseded by @mdxui/neo + @mdxui/blocks;
  * the '@mdxui/beacon' componentSource string literals below are code, left
  * for a follow-up migration. See SG-7 ruling, 2026-07-19.)

--- a/src/generators/site.ts
+++ b/src/generators/site.ts
@@ -2,7 +2,10 @@
  * Site Generator - Marketing Landing Page Generation
  *
  * Generates a marketing landing page from the app definition.
- * Uses @mdxui/beacon components for the UI.
+ * Uses @mdxui/neo section components for the UI.
+ * (@mdxui/beacon is deprecated — superseded by @mdxui/neo + @mdxui/blocks;
+ * the '@mdxui/beacon' componentSource string literals below are code, left
+ * for a follow-up migration. See SG-7 ruling, 2026-07-19.)
  */
 
 import type { AppConfig, ResolvedApp } from '../types'

--- a/src/generators/site/sections.ts
+++ b/src/generators/site/sections.ts
@@ -3,7 +3,7 @@
  *
  * Individual section generators for each landing page component.
  * Each generator creates a SiteSection with content and props
- * suitable for @mdxui/beacon components.
+ * suitable for @mdxui/neo section components.
  *
  * @packageDocumentation
  */

--- a/src/generators/site/sections.ts
+++ b/src/generators/site/sections.ts
@@ -3,7 +3,7 @@
  *
  * Individual section generators for each landing page component.
  * Each generator creates a SiteSection with content and props
- * suitable for @mdxui/neo section components.
+ * targeting @mdxui/neo section components (migration from deprecated @mdxui/beacon queued).
  *
  * @packageDocumentation
  */

--- a/src/generators/site/types.ts
+++ b/src/generators/site/types.ts
@@ -51,7 +51,7 @@ export interface SiteSection {
 
   /**
    * Package source for the component
-   * @example '@mdxui/beacon'
+   * @example '@mdxui/neo'
    */
   componentSource?: string
 


### PR DESCRIPTION
## Ruling

Per **SG-7** (software-spec grill rulings, ratified with the maintainer 2026-07-19; stack vault `research/2026-07-19-software-spec-grill-rulings.md`): **`@mdxui/beacon` is deprecated** (still published on npm and still emitted by this generator's code — see follow-up) — its successor is **`@mdxui/neo`** (sections) with **`@mdxui/blocks`** (block data).

## Changes (docs/comments only)

- `ABSTRACTION.md` — Site output and package-mapping tables now name `@mdxui/neo` + `@mdxui/blocks` as the TARGET (with the beacon-strings-still-emitted caveat inline)
- `README.md` — architecture diagram and "What SaaSkit Generates" table repointed to `@mdxui/neo`
- `src/generators/site.ts` — header doc comment repointed (with an explicit note that the code below still emits `'@mdxui/beacon'` strings)
- `src/generators/site/sections.ts` — header doc comment repointed
- `src/generators/site/types.ts` — `@example` for `componentSource` repointed

## Follow-up (code, deliberately NOT touched here)

- `src/generators/site/constants.ts:158` — `export const DEFAULT_COMPONENT_SOURCE = '@mdxui/beacon'`
- `src/generators/site.ts` — 8 `componentSource: '@mdxui/beacon'` string literals
- `src/__tests__/site-generator.test.ts` — assertions expecting `componentSource === '@mdxui/beacon'` (and its header comments, coupled to those assertions)

These are runtime/test behavior and need a coordinated code migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
